### PR TITLE
Add super for mro

### DIFF
--- a/fmrest/foundset.py
+++ b/fmrest/foundset.py
@@ -10,7 +10,7 @@ class Foundset(object):
 
     Foundsets are used for both find results and portal data (related records)
     """
-    def __init__(self, records: Iterator, info: Dict = {}) -> None:
+    def __init__(self, records: Iterator, info: Dict = {}, *args, **kwargs) -> None:
         """Initialize the Foundset class.
 
         The foundset is cached while being consumed, so that subsequent iterations are possible.
@@ -24,6 +24,7 @@ class Foundset(object):
             Dictionary of information about the foundset. This is 1:1 the dictionary that
             is delivered by FMS for any foundset.
         """
+        super(Foundset, self).__init__(*args, **kwargs)
         self._records = records
         self._consumed = False
         self._info = info

--- a/fmrest/record.py
+++ b/fmrest/record.py
@@ -12,7 +12,7 @@ class Record(object):
     __slots__ = ('_keys', '_values', '_in_portal', '_modifications')
 
     def __init__(self, keys: List[str], values: List[Any],
-                 in_portal: bool = False, type_conversion: bool = False) -> None:
+                 in_portal: bool = False, type_conversion: bool = False, *args, **kwargs) -> None:
         """Initialize the Record class.
 
         Parameters
@@ -31,7 +31,8 @@ class Record(object):
             type of a requested field value. Be cautious with this parameter!
             Values will be converted into int, float, datetime, timedelta, string.
         """
-
+        super(Record, self).__init__(*args, **kwargs)
+        
         self._keys = keys
 
         self._values: List[Any]

--- a/fmrest/server.py
+++ b/fmrest/server.py
@@ -39,7 +39,8 @@ class Server(object):
                  data_sources: Optional[List[Dict]] = None,
                  verify_ssl: Union[bool, str] = True,
                  type_conversion: bool = False,
-                 auto_relogin: bool = False) -> None:
+                 auto_relogin: bool = False,
+		 *args, **kwargs) -> None:
         """Initialize the Server class.
 
         Parameters
@@ -79,6 +80,7 @@ class Server(object):
             request comes back with a 952 (invalid token) error. Defaults to
             False.
         """
+	super(Server, self).__init__(*args, **kwargs)
 
         self.url = url
         self.user = user


### PR DESCRIPTION
Added calls in object __init__() methods to super() to support python's MRO.  Addresses Issue #22.