### PR TITLE
Add FileMaker Cloud support

### DIFF
--- a/fmrest/__init__.py
+++ b/fmrest/__init__.py
@@ -1,3 +1,4 @@
 """python-fmrest is a wrapper around the FileMaker Data API"""
 from .server import Server
+from .cloudserver import CloudServer
 from .const import __version__

--- a/fmrest/cloudserver.py
+++ b/fmrest/cloudserver.py
@@ -4,7 +4,6 @@ import pycognito
 from .const import API_PATH
 from .server import Server
 
-
 class CloudServer(Server):
     """The CloudServer class provides access to a FileMaker Cloud database. This requires authenticating with a
      Claris ID via Amazon Cognito, as described in the FileMaker 19 Data API Guide:
@@ -12,6 +11,12 @@ class CloudServer(Server):
      https://help.claris.com/en/data-api-guide/
 
      Usage is otherwise identical to that of the standard fmrest Server class.
+
+     Please note that the values for cognito_userpool_id and cognito_client_id are the same for all FileMaker Cloud
+     connections at the time of writing, and thus have been provided as default values. These may, however, change in
+     the future, in which case new values may be obtained per instructions here:
+
+     https://help.claris.com/en/customer-console-help/content/create-fmid-token.html
      """
 
     def __init__(self,
@@ -20,8 +25,8 @@ class CloudServer(Server):
                  password: str,
                  database: str,
                  layout: str,
-                 cognito_userpool_id: str,
-                 cognito_client_id: str,
+                 cognito_userpool_id: str = 'us-west-2_NqkuZcXQY',
+                 cognito_client_id: str = '4l9rvl4mv5es1eep1qe97cautn',
                  data_sources: Optional[List[Dict]] = None,
                  verify_ssl: Union[bool, str] = True,
                  type_conversion: bool = False,
@@ -108,7 +113,7 @@ class CloudServer(Server):
         return response.get('token', None)
 
     def _update_token_header(self) -> Dict[str, str]:
-        """Override token header update method to use FMID token if set"""
+        """Override token header update method to use FMID token if set."""
 
         if self._fmid_token:
             self._headers['Authorization'] = 'FMID ' + self._fmid_token

--- a/fmrest/cloudserver.py
+++ b/fmrest/cloudserver.py
@@ -1,11 +1,13 @@
 """Subclass of Server, specifically for connecting via the 'new' FileMaker Cloud"""
 from typing import Dict, List, Optional, Union
+
 try:
     import pycognito
 except ImportError:
     _has_pycognito = False
 else:
     _has_pycognito = True
+
 from .const import API_PATH
 from .server import Server
 
@@ -84,6 +86,12 @@ class CloudServer(Server):
             request comes back with a 952 (invalid token) error. Defaults to
             False.
         """
+
+        if not _has_pycognito:
+            raise ImportError(
+                'Please install pycognito for Claris Cloud support. '
+                'You can do so with: pip install python-fmrest[cloud]'
+            )
 
         super().__init__(url,
                          user,

--- a/fmrest/cloudserver.py
+++ b/fmrest/cloudserver.py
@@ -1,0 +1,127 @@
+"""Subclass of Server, specifically for connecting via the 'new' FileMaker Cloud"""
+from typing import Dict, List, Optional, Union
+import pycognito
+from .const import API_PATH
+from .server import Server
+
+
+class CloudServer(Server):
+    """The CloudServer class provides access to a FileMaker Cloud database. This requires authenticating with a
+     Claris ID via Amazon Cognito, as described in the FileMaker 19 Data API Guide:
+
+     https://help.claris.com/en/data-api-guide/
+
+     Usage is otherwise identical to that of the standard fmrest Server class.
+     """
+
+    def __init__(self,
+                 url: str,
+                 user: str,
+                 password: str,
+                 database: str,
+                 layout: str,
+                 cognito_userpool_id: str,
+                 cognito_client_id: str,
+                 data_sources: Optional[List[Dict]] = None,
+                 verify_ssl: Union[bool, str] = True,
+                 type_conversion: bool = False,
+                 auto_relogin: bool = False
+                 ) -> None:
+        """Initialize the CloudServer class.
+
+        Parameters
+        ----------
+        url : str
+            Address of the FileMaker Cloud Server, e.g. https://myteamname.account.filemaker-cloud.com
+            Note: Data API must use https.
+        user : str
+            Claris ID name to log into your database
+            Note: make sure it belongs to a privilege set that has fmrest extended privileges.
+        password : str
+            Claris ID Password to log into your database
+        database : str
+            Name of database without extension, e.g. Contacts
+        layout : str
+            Layout to work with. Can be changed between calls by setting the layout attribute again,
+            e.g.: fmrest_instance.layout = 'new_layout'.
+        cognito_userpool_id: str
+            Amazon Cognito Userpool ID (required for FileMaker Cloud authentication).
+            See https://help.claris.com/en/customer-console-help/content/create-fmid-token.html
+            At time of writing, this value should be 'us-west-2_NqkuZcXQY'
+        cognito_client_id:
+            Amazon Cognito Client ID (required for FileMaker Cloud authentication).
+            See https://help.claris.com/en/customer-console-help/content/create-fmid-token.html
+            At time of writing, this value should be '4l9rvl4mv5es1eep1qe97cautn'
+        data_sources : list, optional
+            List of dicts in format
+                [{'database': 'db_file', 'username': 'admin', 'password': 'admin'}]
+            Use this if for your actions you need to be authenticated to multiple DB files.
+        verify_ssl : bool or str, optional
+            Switch to set if certificate should be verified.
+            Use False to disable verification. Default True.
+            Use string path to a root cert pem file, if you work with a custom CA.
+        type_conversion : bool, optional
+            If True, attempt to convert string values into their potential original types.
+            In previous versions of the FileMaker Data API only strings were returned and there was
+            no way of knowing the correct type of a requested field value.
+
+            Be cautious with this parameter, as results may be different from what you expect!
+
+            Values will be converted into int, float, datetime, timedelta, string. This happens
+            on a record level, not on a foundset level.
+        auto_relogin : bool, optional
+            If True, tries to automatically get a new token (re-login) when a
+            request comes back with a 952 (invalid token) error. Defaults to
+            False.
+        """
+
+        super().__init__(url,
+                         user,
+                         password,
+                         database,
+                         layout,
+                         data_sources=data_sources,
+                         verify_ssl=verify_ssl,
+                         type_conversion=type_conversion,
+                         auto_relogin=auto_relogin)
+
+        self.cognito_userpool_id = cognito_userpool_id
+        self.cognito_client_id = cognito_client_id
+        self._fmid_token = None
+
+    def _get_cognito_token(self) -> str:
+        """Use Pycognito library to authenticate with Amazon Cognito and retrieve FMID token."""
+
+        user = pycognito.Cognito(user_pool_id=self.cognito_userpool_id,
+                                 client_id=self.cognito_client_id,
+                                 username=self.user)
+        user.authenticate(self.password)
+        return user.id_token
+
+    def _get_bearer_token(self) -> Optional[str]:
+        """Retrieve the bearer token needed to authenticate FileMaker Data API calls."""
+
+        path = API_PATH['auth'].format(database=self.database, token='')
+        data = {'fmDataSource': self.data_sources}
+
+        response = self._call_filemaker('POST', path, data=data)
+        return response.get('token', None)
+
+    def _update_token_header(self) -> Dict[str, str]:
+        """Override token header update method to use FMID token if set"""
+
+        if self._fmid_token:
+            self._headers['Authorization'] = 'FMID ' + self._fmid_token
+        elif self._token:
+            self._headers['Authorization'] = 'Bearer ' + self._token
+        else:
+            self._headers.pop('Authorization', None)
+        return self._headers
+
+    def login(self) -> Optional[str]:
+        """Override Server login so we obtain FMID token from Cognito first"""
+
+        self._fmid_token = self._get_cognito_token()
+        self._token = self._get_bearer_token()
+        self._fmid_token = None  # Reset FMID token so auth headers are set appropriately for data api calls
+        return self._token

--- a/fmrest/cloudserver.py
+++ b/fmrest/cloudserver.py
@@ -1,6 +1,11 @@
 """Subclass of Server, specifically for connecting via the 'new' FileMaker Cloud"""
 from typing import Dict, List, Optional, Union
-import pycognito
+try:
+    import pycognito
+except ImportError:
+    _has_pycognito = False
+else:
+    _has_pycognito = True
 from .const import API_PATH
 from .server import Server
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,6 +38,6 @@ tornado==4.5.2
 tqdm==4.23.4
 traitlets==4.3.2
 twine==1.11.0
-typed-ast==1.1.0
-urllib3==1.25.3
+typed-ast==1.3.1
+urllib3==1.25.4
 wcwidth==0.1.7

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     url='https://github.com/davidhamann/python-fmrest',
     packages=['fmrest'],
     include_package_data=True,
-    install_requires=['requests>=2'],
+    install_requires=['requests>=2',
+                      'pycognito>=0.1.4'],
     classifiers=(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,10 @@ setup(
     url='https://github.com/davidhamann/python-fmrest',
     packages=['fmrest'],
     include_package_data=True,
-    install_requires=['requests>=2',
-                      'pycognito>=0.1.4'],
+    install_requires=['requests>=2'],
+    extras_require={
+        'cloud': ['pycognito>=0.1.4']
+    },
     classifiers=(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',

--- a/tests/unit/test_cloudserver.py
+++ b/tests/unit/test_cloudserver.py
@@ -1,0 +1,99 @@
+"""CloudServer test suite"""
+import unittest
+import json
+import mock
+import requests
+from botocore.exceptions import ClientError
+import pycognito
+import fmrest
+from fmrest.exceptions import FileMakerError, BadJSON
+
+URL = 'https://111.111.111.111'
+ACCOUNT_NAME = 'demo'
+ACCOUNT_PASS = 'demo'
+DATABASE = 'Demo'
+LAYOUT = 'Demo'
+
+def _mock_authenticate_user(_, client=None):
+    """Mock Pycognito authenticate user method. This code is from Pycognito's test suite."""
+    return {
+        "AuthenticationResult": {
+            "TokenType": "admin",
+            "IdToken": "dummy_token",
+            "AccessToken": "dummy_token",
+            "RefreshToken": "dummy_token",
+        }
+    }
+
+def _mock_verify_tokens(self, token, id_name, token_use):
+    """Mock Pycognito verify tokens method. This code is from Pycognito's test suite."""
+    if "wrong" in token:
+        raise pycognito.TokenVerificationException
+    setattr(self, id_name, token)
+
+
+class CloudServerTestCase(unittest.TestCase):
+    """CloudServer test suite.
+
+    Only put mocked requests here that don't need an actual FileMaker Server.
+    """
+
+    def setUp(self) -> None:
+
+        # disable urlib warnings as we are testing with non verified certs
+        requests.packages.urllib3.disable_warnings()
+
+        self._fms = fmrest.CloudServer(url=URL,
+                                       user=ACCOUNT_NAME,
+                                       password=ACCOUNT_PASS,
+                                       database=DATABASE,
+                                       layout=LAYOUT
+                                       )
+
+    def test_bad_cognito_credentials(self):
+        """Test that bad cognito credentials raises a botocore ClientError"""
+        with self.assertRaises(ClientError):
+            self._fms.login()
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('pycognito.aws_srp.AWSSRP.authenticate_user', _mock_authenticate_user)
+    @mock.patch('pycognito.Cognito.verify_token', _mock_verify_tokens)
+    def test_last_error(self, mock_request) -> None:
+        """Test that FileMaker's errorCode response is available via last_error property."""
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {'messages': [{'code': '212'}], 'response': {}}
+        mock_request.return_value = mock_response
+
+        # Error should be None when no request has been made yet
+        self.assertEqual(self._fms.last_error, None)
+
+        # Any FileMaker error code should raise a FileMakerError exception
+        with self.assertRaises(FileMakerError):
+            self._fms.login()
+
+        # Assert last error to be error from mocked response
+        self.assertEqual(self._fms.last_error, 212)
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('pycognito.aws_srp.AWSSRP.authenticate_user', _mock_authenticate_user)
+    @mock.patch('pycognito.Cognito.verify_token', _mock_verify_tokens)
+    def test_bad_json_response(self, mock_request) -> None:
+        """Test handling of invalid JSON response."""
+        mock_response = mock.Mock()
+        mock_response.json.side_effect = json.decoder.JSONDecodeError('test', '', 0)
+        mock_request.return_value = mock_response
+
+        with self.assertRaises(BadJSON):
+            self._fms.login()
+
+    def test_non_ssl_handling(self) -> None:
+        """Make sure you cannot instantiate a Server with an http address."""
+
+        with self.assertRaises(ValueError):
+            fmrest.CloudServer(url="http://127.0.0.1",
+                               user=ACCOUNT_NAME,
+                               password=ACCOUNT_PASS,
+                               database=DATABASE,
+                               layout=LAYOUT
+                               )


### PR DESCRIPTION
This pull request adds a Server subclass, CloudServer, which overrides the `login` method to allow the user to connect to databases hosted via the 'new' style FileMaker Cloud by Claris. This requires the user to sign in with a Claris ID and password. The CloudServer class utilizes the Pycognito library to obtain an FMID token via Amazon Cognito, which is then used to retrieve the access token for use in FileMaker Data API requests.